### PR TITLE
Replace MLGaeming channel link with nocom-specific playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ And [here](https://commons.wikimedia.org/wiki/File:2b2t_Nocom_Overworld_Heatmap.
 Also the teaser trailer is cool: [YouTube (lower quality)](https://www.youtube.com/watch?v=3ayxeruAan8) • [Discord (higher quality)](https://cdn.discordapp.com/attachments/737054779582185522/864051484203286529/nocomment_teaser_trailer.mp4)
 
 Also if you want to see very cool timelapses / renders of nocom data look at these two youtube channels
-* [https://www.youtube.com/c/MLGaeming/videos](https://www.youtube.com/c/MLGaeming/videos)
-* [https://www.youtube.com/user/mcmichiel2307/videos](https://www.youtube.com/user/mcmichiel2307/videos)
+* [MLGaeming](https://www.youtube.com/playlist?list=PLOxa3ecQg7Kixbh1ZXrxJpmoIUUJxy_fv)
+* [Negative_Entropy](https://www.youtube.com/user/mcmichiel2307/videos)
 
 ## Corrections to Fit's video
 * It did not cause an "out of memory" on 2b2t, but rather tick lag to the point where the PaperMC watchdog process would print out the stacktrace. Not a big deal though since the end result is the same (server crashes with stacktrace).


### PR DESCRIPTION
As the MLGaeming channel has new content now, it makes more sense to link to a playlist with the nocom videos specifically. This playlist also includes a couple of unlisted videos not visible on the channel page itself.